### PR TITLE
Update service name for SSH

### DIFF
--- a/roles/devserver/userland-home/files/dereckson/.shell.yml
+++ b/roles/devserver/userland-home/files/dereckson/.shell.yml
@@ -60,6 +60,6 @@ handlers:
     interactive: True
 
   tools:
-    server: "dev.tools.wmflabs.org"
+    server: "dev.toolforge.org"
     command: ['become', '{{%s}}', '{{%s-|}}']
     interactive: True


### PR DESCRIPTION
See https://wikitech.wikimedia.org/wiki/News/Toolforge.org#New_service_names_for_accessing_Toolforge_SSH_bastions for more information