### PR TITLE
Allow Rocky to use CentOS-specific blocks

### DIFF
--- a/roles/core/sshd/files/sshd_config
+++ b/roles/core/sshd/files/sshd_config
@@ -18,7 +18,7 @@
 # but this is overridden so installations will only check .ssh/authorized_keys
 AuthorizedKeysFile	.ssh/authorized_keys
 
-{% if grains['os'] == 'CentOS' -%}
+{% if grains['os_family'] == 'RedHat' -%}
 # Don't use host DSA key (CentOS by default uses it, see T1352)
 HostKey /etc/ssh/ssh_host_rsa_key
 HostKey /etc/ssh/ssh_host_ecdsa_key

--- a/roles/core/userland-software/init.sls
+++ b/roles/core/userland-software/init.sls
@@ -12,7 +12,7 @@
 #   Software sources
 #   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-{% if grains['os'] == 'CentOS' %}
+{% if grains['os_family'] == 'RedHat' && grains['os'] != 'Fedora' %}
 epel-release:
   pkg.installed
 

--- a/roles/paas-docker/docker/software.sls
+++ b/roles/paas-docker/docker/software.sls
@@ -12,7 +12,7 @@
 #   Install Docker engine
 #   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-{% if grains['os'] == 'CentOS' %}
+{% if grains['os_family'] == 'RedHat' && grains['os'] != 'Fedora' %}
 remove_legacy_docker_packages:
   pkg.removed:
     - pkgs:


### PR DESCRIPTION
Sort configuration CentOS-specific and determine if it can be extended to:

- CentOS forks and RHEL (EPEL dependencies)
- Any Fedora downstream (SSH config)